### PR TITLE
Move npm pack to inside build image

### DIFF
--- a/cli/src/utils/build.ts
+++ b/cli/src/utils/build.ts
@@ -2,8 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { createBuild, exportBuild, generateDockerfile } from 'reproducible';
 import { ValistConfig } from '@valist/sdk/dist/types';
-import { defaultImages } from './config';
-import { npmPack } from './npm';
+import { defaultImages, parsePackageJson } from './config';
 
 export const buildRelease = async ({
   image,
@@ -12,21 +11,23 @@ export const buildRelease = async ({
   out,
   type,
 }: ValistConfig): Promise<fs.ReadStream> => {
-  let releaseFile;
+  let buildCommand = build;
+  let outArtifact = out;
+
+  if (type === 'node') {
+    const packageJson = parsePackageJson();
+    buildCommand = `${build} && npm pack`;
+    outArtifact = `${packageJson.name}-${packageJson.version}.tgz`;
+  }
 
   // Generate Dockerfile (uses current directory as source)
-  generateDockerfile(image || defaultImages[type], './', build, install);
+  generateDockerfile(image || defaultImages[type], './', buildCommand, install);
 
   await createBuild('valist-build-image');
-  await exportBuild('valist-build-image', out);
+  await exportBuild('valist-build-image', outArtifact);
 
   // if package type is npm run npm pack
-  if (type === 'node') {
-    const packagePath = await npmPack();
-    releaseFile = fs.createReadStream(packagePath);
-  } else {
-    releaseFile = fs.createReadStream(path.join(process.cwd(), out));
-  }
+  const releaseFile = fs.createReadStream(path.join(process.cwd(), outArtifact));
 
   return releaseFile;
 };

--- a/cli/src/utils/config.ts
+++ b/cli/src/utils/config.ts
@@ -1,5 +1,6 @@
 import * as yaml from 'js-yaml';
 import * as fs from 'fs';
+import * as path from 'path';
 import Valist from '@valist/sdk';
 import type { ValistConfig, ProjectType } from '@valist/sdk/dist/types';
 import { getWeb3Provider, getSignerKey } from './crypto';
@@ -62,6 +63,21 @@ export const defaultBuilds: Record<ProjectType, string> = {
   docker: '',
   'c++': 'make build',
   static: '',
+};
+
+export type PackageJson = {
+  name: string,
+  version: string
+};
+
+export const parsePackageJson = ():PackageJson => {
+  const { name, version } = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+  const packageJSON: PackageJson = {
+    name,
+    version,
+  };
+
+  return packageJSON;
 };
 
 export const parseValistConfig = (): ValistConfig => {


### PR DESCRIPTION
Fixes npm packages not being reproducible due to differences in NPM pack tar-encoding  between version of NPM.