### PR TITLE
Multi-platform valist release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ site
 *.dylib
 *.test
 *.out
+dist

--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,19 @@ bin:
 	go build -ldflags "-s -w" ./cmd/valist
 
 bin-linux-amd64:
-	GOOS=linux   GOARCH=amd64 go build -ldflags "-s -w" -o dist/linux-amd64/valist   ./cmd/valist
+	GOOS=linux   GOARCH=amd64 go build -ldflags "-s -w" -o dist/linux-amd64/valist       ./cmd/valist
 
 bin-linux-arm64:
-	GOOS=linux   GOARCH=arm64 go build -ldflags "-s -w" -o dist/linux-arm64/valist   ./cmd/valist
+	GOOS=linux   GOARCH=arm64 go build -ldflags "-s -w" -o dist/linux-arm64/valist       ./cmd/valist
 
 bin-darwin-amd64:
-	GOOS=darwin  GOARCH=amd64 go build -ldflags "-s -w" -o dist/darwin-amd64/valist  ./cmd/valist
+	GOOS=darwin  GOARCH=amd64 go build -ldflags "-s -w" -o dist/darwin-amd64/valist      ./cmd/valist
 
 bin-darwin-arm64:
-	GOOS=darwin  GOARCH=arm64 go build -ldflags "-s -w" -o dist/darwin-arm64/valist  ./cmd/valist
+	GOOS=darwin  GOARCH=arm64 go build -ldflags "-s -w" -o dist/darwin-arm64/valist      ./cmd/valist
 
 bin-windows-amd64:
-	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o dist/windows-amd64/valist ./cmd/valist
+	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o dist/windows-amd64/valist.exe ./cmd/valist
 
 bin-multi: bin-linux-amd64 bin-linux-arm64 bin-darwin-amd64 bin-darwin-arm64 bin-windows-amd64
 
@@ -51,6 +51,7 @@ web-lib:
 	npm run build --prefix ./web/lib
 
 web-relay:
+	rm -rf ./web/relay/out
 	npm run build --prefix ./web/relay
 	npm run export --prefix ./web/relay
 
@@ -77,5 +78,13 @@ test: test-valist test-web-lib
 
 docs:
 	mkdocs build
+
+clean:
+	rm -rf ./web/relay/.next
+	rm -rf ./web/relay/out
+	rm -rf ./web/relay/node_modules
+	rm -rf ./web/lib/node_modules
+	rm -rf ./web/lib/dist
+	rm -rf dist site
 
 .PHONY: web docs

--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,22 @@ SHELL=/bin/bash
 all: install valist
 
 bin:
-	go build ./cmd/valist
+	go build -ldflags "-s -w" ./cmd/valist
 
 bin-linux-amd64:
-	GOOS=linux   GOARCH=amd64 go build -o dist/linux-amd64/valist   ./cmd/valist
+	GOOS=linux   GOARCH=amd64 go build -ldflags "-s -w" -o dist/linux-amd64/valist   ./cmd/valist
 
 bin-linux-arm64:
-	GOOS=linux   GOARCH=arm64 go build -o dist/linux-arm64/valist   ./cmd/valist
+	GOOS=linux   GOARCH=arm64 go build -ldflags "-s -w" -o dist/linux-arm64/valist   ./cmd/valist
 
 bin-darwin-amd64:
-	GOOS=darwin  GOARCH=amd64 go build -o dist/darwin-amd64/valist  ./cmd/valist
+	GOOS=darwin  GOARCH=amd64 go build -ldflags "-s -w" -o dist/darwin-amd64/valist  ./cmd/valist
 
 bin-darwin-arm64:
-	GOOS=darwin  GOARCH=arm64 go build -o dist/darwin-arm64/valist  ./cmd/valist
+	GOOS=darwin  GOARCH=arm64 go build -ldflags "-s -w" -o dist/darwin-arm64/valist  ./cmd/valist
 
 bin-windows-amd64:
-	GOOS=windows GOARCH=amd64 go build -o dist/windows-amd64/valist ./cmd/valist
+	GOOS=windows GOARCH=amd64 go build -ldflags "-s -w" -o dist/windows-amd64/valist ./cmd/valist
 
 bin-multi: bin-linux-amd64 bin-linux-arm64 bin-darwin-amd64 bin-darwin-arm64 bin-windows-amd64
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,23 @@ all: install valist
 bin:
 	go build ./cmd/valist
 
+bin-linux-amd64:
+	GOOS=linux   GOARCH=amd64 go build -o dist/linux-amd64/valist   ./cmd/valist
+
+bin-linux-arm64:
+	GOOS=linux   GOARCH=arm64 go build -o dist/linux-arm64/valist   ./cmd/valist
+
+bin-darwin-amd64:
+	GOOS=darwin  GOARCH=amd64 go build -o dist/darwin-amd64/valist  ./cmd/valist
+
+bin-darwin-arm64:
+	GOOS=darwin  GOARCH=arm64 go build -o dist/darwin-arm64/valist  ./cmd/valist
+
+bin-windows-amd64:
+	GOOS=windows GOARCH=amd64 go build -o dist/windows-amd64/valist ./cmd/valist
+
+bin-multi: bin-linux-amd64 bin-linux-arm64 bin-darwin-amd64 bin-darwin-arm64 bin-windows-amd64
+
 valist: web bin
 
 install: install-lib install-relay
@@ -60,21 +77,5 @@ test: test-valist test-web-lib
 
 docs:
 	mkdocs build
-
-# runs local typescript compiler in watch mode
-dev-lib:
-	npm run dev --prefix ./web/lib
-
-# runs local next server
-dev-relay:
-	npm run dev --prefix ./web/relay
-
-# hot reload docs
-dev-docs:
-	mkdocs serve
-
-# runs both dev servers in parallel, piping output to same shell
-dev:
-	@make -j 2 dev-lib dev-relay
 
 .PHONY: web docs

--- a/valist.yml
+++ b/valist.yml
@@ -7,7 +7,7 @@ install:
   curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
 
   RUN apt install -yy nodejs
-build: make clean install bin-multi
+build: make clean install web bin-multi
 out: dist
 platforms:
   linux/amd64: linux-amd64/valist

--- a/valist.yml
+++ b/valist.yml
@@ -7,7 +7,7 @@ install:
   curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
 
   RUN apt install -yy nodejs
-build: make install bin-multi
+build: make clean install bin-multi
 out: dist
 platforms:
   linux/amd64: linux-amd64/valist

--- a/valist.yml
+++ b/valist.yml
@@ -7,5 +7,11 @@ install:
   curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
 
   RUN apt install -yy nodejs
-build: make
-out: ./valist
+build: make install bin-multi
+out: dist
+platforms:
+  linux/amd64: linux-amd64/valist
+  linux/arm64: linux-arm64/valist
+  darwin/amd64: darwin-amd64/valist
+  darwin/arm64: darwin-arm64/valist
+  windows/amd64: windows-amd64/valist


### PR DESCRIPTION
This modifies the Makefile and valist.yml to build for the following platforms:

linux/amd64
linux/arm64
darwin/amd64
darwin/arm64
windows/amd64

the windows/arm64 builds are currently failing, so leaving that out for now