### PR TITLE
add signer env override test

### DIFF
--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -19,6 +19,8 @@ import (
 	"github.com/valist-io/valist/internal/prompt"
 )
 
+const EnvKey = "VALIST_SIGNER"
+
 // Signer signs transactions.
 type Signer struct {
 	account accounts.Account
@@ -36,7 +38,7 @@ func NewSigner(chainID *big.Int, backends ...accounts.Backend) (*Signer, error) 
 		cache:   make(map[common.Address]string),
 	}
 
-	privatekey := os.Getenv("VALIST_SIGNER")
+	privatekey := os.Getenv(EnvKey)
 	if privatekey == "" {
 		return signer, nil
 	}

--- a/internal/signer/signer_test.go
+++ b/internal/signer/signer_test.go
@@ -1,0 +1,38 @@
+package signer
+
+import (
+	"math/big"
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvironmentOverride(t *testing.T) {
+	private, err := crypto.GenerateKey()
+	require.NoError(t, err, "failed to generate private key")
+
+	address := crypto.PubkeyToAddress(private.PublicKey)
+	account := accounts.Account{Address: address}
+
+	key := common.Bytes2Hex(crypto.FromECDSA(private))
+	err = os.Setenv(EnvKey, key)
+	require.NoError(t, err, "failed to set environment")
+
+	signer, err := NewSigner(big.NewInt(1337))
+	require.NoError(t, err, "failed to create signer")
+	
+	assert.Equal(t, address, signer.account.Address)
+	assert.Len(t, signer.manager.Accounts(), 1)
+
+	wallet, err := signer.manager.Find(account)
+	require.NoError(t, err, "failed to find wallet")
+
+	// ensure the wallet is unlocked by signing arbitrary text
+	_, err = wallet.SignText(account, []byte("hello"))
+	require.NoError(t, err, "failed to sign text")
+}


### PR DESCRIPTION
This test is a simple sanity check so we don't break the signer in CI environments.