### PR TITLE
Fix Init Command

### DIFF
--- a/command/init_test.go
+++ b/command/init_test.go
@@ -15,7 +15,7 @@ func TestInitCommand(t *testing.T) {
 
 	err = os.Chdir(t.TempDir())
 	require.NoError(t, err, "failed to change dir")
-	t.Cleanup(func() { os.Chdir(cwd) })
+	t.Cleanup(func() { os.Chdir(cwd) }) //nolint:errcheck
 
 	err = Init(context.Background(), "valist/sdk", false)
 	require.NoError(t, err, "failed to init valist project")

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -1,0 +1,25 @@
+package command
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitCommand(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err, "failed to get working dir")
+
+	err = os.Chdir(t.TempDir())
+	require.NoError(t, err, "failed to change dir")
+	t.Cleanup(func() { os.Chdir(cwd) })
+
+	err = Init(context.Background(), "valist/sdk", false)
+	require.NoError(t, err, "failed to init valist project")
+
+	err = Init(context.Background(), "valist/sdk", false)
+	assert.ErrorIs(t, err, ErrProjectExist)
+}


### PR DESCRIPTION
This fixes a bug where the init command would fail even when the `valist.yml` does not exist.